### PR TITLE
Shield fast sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 shield*.json
+shield.bin

--- a/app.js
+++ b/app.js
@@ -2,12 +2,12 @@ import * as dotenv from "dotenv";
 dotenv.config();
 checkEnv();
 import express from "express";
-import fetch from "node-fetch";
 import cors from "cors";
 import http from "http";
 import https from "https";
-import fs from "fs";
 import jq from "node-jq";
+import { shield, beginShieldSync, getShieldBinary } from "./shield.js";
+import { makeRpc } from "./rpc.js";
 
 const app = express();
 app.use(cors());
@@ -15,16 +15,12 @@ const port = process.env["PORT"] || 3000;
 const rpcPort = process.env["RPC_PORT"] || 51473;
 const testnetRpcPort = process.env["TESTNET_RPC_PORT"];
 const allowedRpcs = process.env["ALLOWED_RPCS"].split(",");
-const shield = {
-    testnet: [],
-    mainnet: [],
-};
 
 function setupServer(app) {
   if (testnetRpcPort) {
-      beginShieldSync(true);
+    beginShieldSync(true);
   }
-    
+
   beginShieldSync(false);
   const certificatePath = process.env["HTTPS_CERTIFICATE_PATH"];
   const keyPath = process.env["HTTPS_KEY_PATH"];
@@ -43,51 +39,6 @@ function checkEnv() {
     throw new Error("Environment variable RPC_CREDENTIALS was not set");
 }
 
-const encodeBase64 = (data) => {
-  return Buffer.from(data).toString("base64");
-};
-
-async function makeRpc(isTestnet, name, ...params) {
-  try {
-    const output = await fetch(
-      `http://127.0.0.1:${isTestnet ? testnetRpcPort : rpcPort}/`,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "text/plain;",
-          Authorization:
-            "Basic " + encodeBase64(process.env["RPC_CREDENTIALS"]),
-        },
-        body: JSON.stringify({
-          jsonrpc: "1.0",
-          id: "pivxRerouter",
-          method: name,
-          params,
-        }),
-      }
-    );
-
-    const obj = await output.json();
-    if (obj.error) {
-      const imATeapot = 418;
-      return { status: imATeapot, response: obj.error.message };
-    } else {
-      const ok = 200;
-      return { status: ok, response: JSON.stringify(obj.result) };
-    }
-  } catch (error) {
-    if (error.errno === "ECONNREFUSED") {
-      return { status: 503, response: "PIVX node was not responsive." };
-    }
-    console.error(error);
-    if (error.name === "AbortError") {
-      return "brequbest was aborted'";
-    } else {
-      return "non u sac";
-    }
-  }
-}
-
 function parseParams(params) {
   return (params ? params.split(",") : [])
     .map((v) => (isNaN(v) ? v : parseInt(v)))
@@ -103,7 +54,7 @@ async function handleRequest(isTestnet, req, res) {
       const { status, response } = await makeRpc(
         isTestnet,
         req.params["rpc"],
-        ...params
+        ...params,
       );
       try {
         res
@@ -111,7 +62,7 @@ async function handleRequest(isTestnet, req, res) {
           .send(
             filter
               ? await jq.run(filter, response, { input: "string" })
-              : response
+              : response,
           );
       } catch (e) {
         const badRequest = 400;
@@ -128,59 +79,35 @@ async function handleRequest(isTestnet, req, res) {
   }
 }
 
-app.get('/mainnet/getshieldblocks', async function(req, res) {
-    res.send(JSON.stringify(shield["mainnet"]));
+app.get("/mainnet/getshieldblocks", async function (req, res) {
+  res.send(JSON.stringify(shield["mainnet"].map(({ block }) => block)));
+});
+
+app.get("/mainnet/getshielddata", async (req, res) => {
+  const startBlock = req.query.startBlock || 0;
+  const startingByte = shield["mainnet"]
+    // Get the first block that's greater or equal than the requested starting block
+    .find(({ block }) => block >= startBlock)?.i;
+  console.log(startingByte);
+  if (startingByte === undefined) {
+    const noContent = 204;
+    res.status(noContent).send(Buffer.from([]));
+    return;
+  }
+
+  res.send(await getShieldBinary(false, startingByte));
 });
 
 app.get("/mainnet/:rpc", async (req, res) => handleRequest(false, req, res));
 if (testnetRpcPort) {
-    app.get('/testnet/getshieldblocks', async function(req, res) {
-	res.send(JSON.stringify(shield["testnet"]));
-    });
-    app.get("/testnet/:rpc", async (req, res) => handleRequest(true, req, res));
+  app.get("/testnet/getshieldblocks", async function (req, res) {
+    res.send(JSON.stringify(shield["testnet"]));
+  });
+  app.get("/testnet/:rpc", async (req, res) => handleRequest(true, req, res));
 }
-
 
 const server = setupServer(app);
 
 server.listen(port, () => {
   console.log(`Pivx node controller listening on port ${port}`);
 });
-
-async function beginShieldSync(isTestnet) {
-    shield[isTestnet ? "testnet" : "mainnet"] = JSON.parse(fs.readFileSync(isTestnet ? 'shield.testnet.json' : 'shield.json')) || [];
-    const currentShield = shield[isTestnet ? "testnet" : "mainnet"];
-    try {
-	let block = currentShield.length ? currentShield[currentShield.length - 1] + 1 : 0;
-	let { status, response } = await makeRpc(isTestnet, "getblockhash", block);
-	let blockHash = JSON.parse(response);
-	console.log(block);
-	
-	while (true) {
-	    const { status, response } = await makeRpc(isTestnet, "getblock", blockHash, 2);
-	    const { tx, nextblockhash } = JSON.parse(response);
-	    if (status === 200) {
-		const isShield = !!tx.find(b => b.hex.startsWith("03"));
-		if(isShield) {
-		    currentShield.push(block);
-		}
-		blockHash = nextblockhash;
-		block += 1;
-		if (block % 10000 === 0) {
-		    console.error(block);
-		    console.error(currentShield);
-		}
-	    } else {
-		throw new Error(response);
-	    }
-	    if (!nextblockhash) {
-		break;
-	    }
-	}
-    } catch (e) {
-	console.error(e);
-    } finally {
-	fs.writeFileSync(isTestnet ? "shield.testnet.json" : "shield.json", JSON.stringify(currentShield));
-	setTimeout(() => beginShieldSync(isTestnet), 1000 * 60); // Sync every minute
-    }
-};

--- a/rpc.js
+++ b/rpc.js
@@ -1,0 +1,49 @@
+import fetch from "node-fetch";
+
+const port = process.env["PORT"] || 3000;
+const rpcPort = process.env["RPC_PORT"] || 51473;
+const testnetRpcPort = process.env["TESTNET_RPC_PORT"];
+
+const encodeBase64 = (data) => {
+  return Buffer.from(data).toString("base64");
+};
+
+export async function makeRpc(isTestnet, name, ...params) {
+  try {
+    const output = await fetch(
+      `http://127.0.0.1:${isTestnet ? testnetRpcPort : rpcPort}/`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain;",
+          Authorization:
+            "Basic " + encodeBase64(process.env["RPC_CREDENTIALS"]),
+        },
+        body: JSON.stringify({
+          jsonrpc: "1.0",
+          id: "pivxRerouter",
+          method: name,
+          params,
+        }),
+      },
+    );
+    const obj = await output.json();
+    if (obj.error) {
+      const imATeapot = 418;
+      return { status: imATeapot, response: obj.error.message };
+    } else {
+      const ok = 200;
+      return { status: ok, response: JSON.stringify(obj.result) };
+    }
+  } catch (error) {
+    if (error.errno === "ECONNREFUSED") {
+      return { status: 503, response: "PIVX node was not responsive." };
+    }
+    console.error(error);
+    if (error.name === "AbortError") {
+      return "brequbest was aborted'";
+    } else {
+      return "non u sac";
+    }
+  }
+}

--- a/shield.js
+++ b/shield.js
@@ -40,7 +40,7 @@ export async function beginShieldSync(isTestnet) {
   let previousBlock = size;
   try {
     let block = currentShield.length
-      ? currentShield[currentShield.length - 1] + 1
+      ? currentShield[currentShield.length - 1].block + 1
       : 2700501;
     let { status, response } = await makeRpc(isTestnet, "getblockhash", block);
     let blockHash = JSON.parse(response);

--- a/shield.js
+++ b/shield.js
@@ -1,0 +1,117 @@
+import fs from "fs/promises";
+import { makeRpc } from "./rpc.js";
+
+export const shield = {
+  testnet: [],
+  mainnet: [],
+};
+
+const shieldArrayFile = (isTestnet) =>
+  isTestnet ? "shield.testnet.json" : "shield.json";
+const shieldBinFile = (isTestnet) =>
+  isTestnet ? "shield.testnet.bin" : "shield.bin";
+
+async function recoverShieldbin(isTestnet) {
+  // If the shield bin was written, but the index was not
+  // We would repeat some blocks
+  // So we truncate the file based on the last index we have
+  const currentShield = shield[isTestnet ? "testnet" : "mainnet"];
+  let lastBlock = currentShield.at(-1);
+  if (!lastBlock) return;
+  const file = await fs.open(shieldBinFile(isTestnet), "r+");
+  const buffer = Buffer.alloc(4);
+  file.read(buffer, 0, 4, lastBlock.i);
+  const length = buffer.readInt32LE();
+  await file.close();
+  await fs.truncate(shieldBinFile(isTestnet), lastBlock.i + length);
+}
+
+export async function beginShieldSync(isTestnet) {
+  shield[isTestnet ? "testnet" : "mainnet"] =
+    JSON.parse(await fs.readFile(shieldArrayFile(isTestnet))) || [];
+  const currentShield = shield[isTestnet ? "testnet" : "mainnet"];
+  const { size } = await fs.stat(shieldBinFile(isTestnet));
+
+  await recoverShieldbin(isTestnet);
+
+  const file = await fs.open(shieldBinFile(isTestnet), "a");
+  const stream = file.createWriteStream();
+  let writtenBytes = 0;
+  let previousBlock = size;
+  try {
+    let block = currentShield.length
+      ? currentShield[currentShield.length - 1] + 1
+      : 2700501;
+    let { status, response } = await makeRpc(isTestnet, "getblockhash", block);
+    let blockHash = JSON.parse(response);
+
+    while (true) {
+      const { status, response } = await makeRpc(
+        isTestnet,
+        "getblock",
+        blockHash,
+        2,
+      );
+      const { tx, nextblockhash, time, height } = JSON.parse(response);
+      if (status === 200) {
+        let isShield = false;
+        for (const transaction of tx) {
+          if (transaction.hex.startsWith("03")) {
+            isShield = true;
+            const length = Buffer.alloc(4);
+            length.writeUint32LE(transaction.hex.length / 2);
+            stream.write(length);
+            stream.write(Buffer.from(transaction.hex, "hex"));
+            writtenBytes += transaction.hex.length / 2 + 4;
+          }
+        }
+
+        if (isShield) {
+          const bytes = Buffer.alloc(1 + 4 + 4 + 4);
+          // 5d indicates start of new block
+          // Other `5d`s are not escaped, this should not
+          // be relied upon, it's just confirmation that
+          // the stream is being read correctly
+          const length = Buffer.alloc(4);
+          length.writeUint32LE(1 + 4 + 4);
+          length.copy(bytes, 0, 0, bytes.length);
+          bytes.writeUint8(0x5d, 4);
+          bytes.writeInt32LE(height, 5);
+          bytes.writeInt32LE(time, 9);
+          writtenBytes += bytes.byteLength;
+          stream.write(bytes);
+          currentShield.push({ block, i: previousBlock });
+          previousBlock = size + writtenBytes;
+        }
+
+        blockHash = nextblockhash;
+        block += 1;
+        if (block % 10000 === 0) {
+          console.error(block);
+        }
+      } else {
+        throw new Error(response);
+      }
+      if (!nextblockhash) {
+        break;
+      }
+    }
+  } catch (e) {
+    console.error(e);
+  } finally {
+    await fs.writeFile(
+      shieldArrayFile(isTestnet),
+      JSON.stringify(currentShield),
+    );
+    await new Promise((res) => {
+      stream.close(res);
+    });
+    setTimeout(() => beginShieldSync(isTestnet), 1000 * 60); // Sync every minute
+  }
+}
+
+export async function getShieldBinary(isTestnet, startingByte = 0) {
+  const buffer = await fs.readFile(shieldBinFile(isTestnet));
+
+  return Uint8Array.prototype.slice.call(buffer, startingByte);
+}

--- a/shield.js
+++ b/shield.js
@@ -22,19 +22,16 @@ async function recoverShieldbin(isTestnet) {
   const buffer = Buffer.alloc(4);
   let blockLength = 0;
   while (true) {
-    file.read(buffer, 0, 4, lastBlock.i + blockLength);
+    await file.read(buffer, 0, 4, lastBlock.i + blockLength);
     const length = buffer.readInt32LE();
-    file.read(buffer, 0, 4, lastBlock.i + blockLength + 4);
-    const version = buffer.readInt32LE();
-    if (version === 3) {
-      // This is a transaction
+    await file.read(buffer, 0, 4, lastBlock.i + blockLength + 4);
+      const version = buffer.readInt32LE();
       blockLength += length;
-    } else {
-      // This is a block footer
-      // After this it's the beginning of a new block
-      blockLength += length;
-      break;
-    }
+      if (version !== 3) {
+	  // This is a block footer
+	  // After this it's the beginning of a new block
+	  break;
+      }
   }
   await file.close();
   await fs.truncate(shieldBinFile(isTestnet), lastBlock.i + blockLength);

--- a/shield.js
+++ b/shield.js
@@ -130,4 +130,3 @@ export async function getShieldBinary(isTestnet, startingByte = 0) {
 
   return Uint8Array.prototype.slice.call(buffer, startingByte);
 }
-9;

--- a/shield.js
+++ b/shield.js
@@ -21,17 +21,18 @@ async function recoverShieldbin(isTestnet) {
   const file = await fs.open(shieldBinFile(isTestnet), "r+");
   const buffer = Buffer.alloc(4);
   let blockLength = 0;
-  let isFirstHeader = true;
   while (true) {
     file.read(buffer, 0, 4, lastBlock.i + blockLength);
     const length = buffer.readInt32LE();
     file.read(buffer, 0, 4, lastBlock.i + blockLength + 4);
     const version = buffer.readInt32LE();
-    // This is a tx or it's the first header, so it's part of the block
-    if (version === 3 || isFirstHeader) {
-      isFirstHeader = false;
+    if (version === 3) {
+      // This is a transaction
       blockLength += length;
     } else {
+      // This is a block footer
+      // After this it's the beginning of a new block
+      blockLength += length;
       break;
     }
   }
@@ -128,3 +129,4 @@ export async function getShieldBinary(isTestnet, startingByte = 0) {
 
   return Uint8Array.prototype.slice.call(buffer, startingByte);
 }
+9;


### PR DESCRIPTION
# Abstract
- Split app.js in 3 files for readability
- Add an API endpoint to return the shield data, starting from the provided block in the following format:
```
{[tx length 4 bytes][tx]}* # Repeat for every tx in a block (First byte of tx should always be 3, the version)
{[block info length (Should always be 9)][0x5d (Magic to distinguish from tx version][blockHeight 4 bytes][blockTime 4 bytes]}
```
- Changed the shield variable to include the block count and the position of it in the binary file

Before updating, the shield json should be resetted to an empty array.

TODO: add testnet endpoint